### PR TITLE
Corrected an erroneous include directive.

### DIFF
--- a/Input/Regex/RegexSyntaxTree.h
+++ b/Input/Regex/RegexSyntaxTree.h
@@ -4,7 +4,7 @@
 #include "ErrorLoc.h"
 #include "NondeterministicFiniteAutomata.h"
 
-#include <exception>
+#include <stdexcept>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
std::runtime_error requires the stdexcept header, not the exception header.